### PR TITLE
utilize Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
   </scm>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <hsqldb.version>2.3.3</hsqldb.version>
     <slf4j.version>1.6.6</slf4j.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>extension-persistence</artifactId>
-  <version>0.3.3-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git@git.gcx.org:java/extension-persistence.git</connection>

--- a/src/main/java/org/ccci/gto/persistence/tx/Closure.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/Closure.java
@@ -1,0 +1,6 @@
+package org.ccci.gto.persistence.tx;
+
+@FunctionalInterface
+public interface Closure<T, X extends Throwable> {
+    T run() throws X;
+}

--- a/src/main/java/org/ccci/gto/persistence/tx/DefaultRetryingTransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/DefaultRetryingTransactionService.java
@@ -1,37 +1,4 @@
 package org.ccci.gto.persistence.tx;
 
-import org.ccci.gto.persistence.DeadLockRetry;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.Callable;
-
-public class DefaultRetryingTransactionService extends DefaultTransactionService implements RetryingTransactionService {
-    @Override
-    @DeadLockRetry
-    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
-    public void inRetryingReadOnlyTransaction(final Runnable command) {
-        command.run();
-    }
-
-    @Override
-    @DeadLockRetry
-    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
-    public <T> T inRetryingReadOnlyTransaction(final Callable<T> command) throws Exception {
-        return command.call();
-    }
-
-    @Override
-    @DeadLockRetry
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void inRetryingTransaction(final Runnable command) {
-        command.run();
-    }
-
-    @Override
-    @DeadLockRetry
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public <T> T inRetryingTransaction(final Callable<T> command) throws Exception {
-        return command.call();
-    }
-}
+public class DefaultRetryingTransactionService extends DefaultTransactionService implements
+        RetryingTransactionService {}

--- a/src/main/java/org/ccci/gto/persistence/tx/DefaultTransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/DefaultTransactionService.java
@@ -1,31 +1,3 @@
 package org.ccci.gto.persistence.tx;
 
-import java.util.concurrent.Callable;
-
-import org.springframework.transaction.annotation.Transactional;
-
-public class DefaultTransactionService implements TransactionService {
-    @Override
-    @Transactional(readOnly = true)
-    public void inReadOnlyTransaction(final Runnable command) {
-        command.run();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public <T> T inReadOnlyTransaction(final Callable<T> command) throws Exception {
-        return command.call();
-    }
-
-    @Override
-    @Transactional
-    public void inTransaction(final Runnable command) {
-        command.run();
-    }
-
-    @Override
-    @Transactional
-    public <T> T inTransaction(final Callable<T> command) throws Exception {
-        return command.call();
-    }
-}
+public class DefaultTransactionService implements TransactionService {}

--- a/src/main/java/org/ccci/gto/persistence/tx/ReadOnlyTransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/ReadOnlyTransactionService.java
@@ -1,9 +1,17 @@
 package org.ccci.gto.persistence.tx;
 
-import java.util.concurrent.Callable;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nonnull;
 
 public interface ReadOnlyTransactionService {
-    void inReadOnlyTransaction(Runnable command);
+    @Transactional(readOnly = true)
+    default void inReadOnlyTransaction(@Nonnull final Runnable command) {
+        command.run();
+    }
 
-    <T> T inReadOnlyTransaction(Callable<T> command) throws Exception;
+    @Transactional(readOnly = true)
+    default <T, X extends Throwable> T inReadOnlyTransaction(@Nonnull final Closure<T, X> command) throws X {
+        return command.run();
+    }
 }

--- a/src/main/java/org/ccci/gto/persistence/tx/RetryingReadOnlyTransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/RetryingReadOnlyTransactionService.java
@@ -1,9 +1,21 @@
 package org.ccci.gto.persistence.tx;
 
-import java.util.concurrent.Callable;
+import org.ccci.gto.persistence.DeadLockRetry;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nonnull;
 
 public interface RetryingReadOnlyTransactionService extends ReadOnlyTransactionService {
-    void inRetryingReadOnlyTransaction(Runnable command);
+    @DeadLockRetry
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    default void inRetryingReadOnlyTransaction(@Nonnull final Runnable command) {
+        command.run();
+    }
 
-    <T> T inRetryingReadOnlyTransaction(Callable<T> command) throws Exception;
+    @DeadLockRetry
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    default <T, X extends Throwable> T inRetryingReadOnlyTransaction(@Nonnull final Closure<T, X> command) throws X {
+        return command.run();
+    }
 }

--- a/src/main/java/org/ccci/gto/persistence/tx/RetryingTransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/RetryingTransactionService.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 public interface RetryingTransactionService extends TransactionService, RetryingReadOnlyTransactionService {
     @DeadLockRetry
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    default void inRetryingTransaction(Runnable command) {
+    default void inRetryingTransaction(@Nonnull final Runnable command) {
         command.run();
     }
 

--- a/src/main/java/org/ccci/gto/persistence/tx/RetryingTransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/RetryingTransactionService.java
@@ -1,9 +1,21 @@
 package org.ccci.gto.persistence.tx;
 
-import java.util.concurrent.Callable;
+import org.ccci.gto.persistence.DeadLockRetry;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nonnull;
 
 public interface RetryingTransactionService extends TransactionService, RetryingReadOnlyTransactionService {
-    void inRetryingTransaction(Runnable command);
+    @DeadLockRetry
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    default void inRetryingTransaction(Runnable command) {
+        command.run();
+    }
 
-    <T> T inRetryingTransaction(Callable<T> command) throws Exception;
+    @DeadLockRetry
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    default <T, X extends Throwable> T inRetryingTransaction(@Nonnull final Closure<T, X> command) throws X {
+        return command.run();
+    }
 }

--- a/src/main/java/org/ccci/gto/persistence/tx/TransactionService.java
+++ b/src/main/java/org/ccci/gto/persistence/tx/TransactionService.java
@@ -1,9 +1,17 @@
 package org.ccci.gto.persistence.tx;
 
-import java.util.concurrent.Callable;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nonnull;
 
 public interface TransactionService extends ReadOnlyTransactionService {
-    void inTransaction(Runnable command);
+    @Transactional
+    default void inTransaction(@Nonnull final Runnable command) {
+        command.run();
+    }
 
-    <T> T inTransaction(Callable<T> command) throws Exception;
+    @Transactional
+    default <T, X extends Throwable> T inTransaction(@Nonnull final Closure<T, X> command) throws X {
+        return command.run();
+    }
 }


### PR DESCRIPTION
- Require Java 8
- Utilize interface default methods
- switch from using `Callable` to new `Closure` method to utilize generics for checked exceptions