### PR TITLE
Support multiple EntityManagers in DeadLockRetry AOP logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>jsr305</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>extension-persistence</artifactId>
-  <version>0.4.1-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git@git.gcx.org:java/extension-persistence.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Spring AOP dependencies -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Annotation dependencies -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,16 +26,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjrt</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-entitymanager</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -48,6 +38,21 @@
       <artifactId>spring-tx</artifactId>
     </dependency>
 
+    <!-- AspectJ dependencies -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Hibernate dependencies -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-entitymanager</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Annotation dependencies -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
@@ -59,6 +64,7 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/java/org/ccci/gto/persistence/DeadLockDetector.java
+++ b/src/main/java/org/ccci/gto/persistence/DeadLockDetector.java
@@ -1,0 +1,8 @@
+package org.ccci.gto.persistence;
+
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+
+public interface DeadLockDetector {
+    boolean isDeadlock(@Nonnull EntityManager em, @Nonnull Throwable e);
+}

--- a/src/main/java/org/ccci/gto/persistence/DeadLockRetry.java
+++ b/src/main/java/org/ccci/gto/persistence/DeadLockRetry.java
@@ -8,10 +8,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface DeadLockRetry {
+    int DEFAULT_ATTEMPTS = -1;
+
     /**
-     * Retry count. -1 indicates to use the default number of retries.
+     * Retry count. {@link DeadLockRetry#DEFAULT_ATTEMPTS} indicates to use the default number of retries.
      */
-    int attempts() default -1;
+    int attempts() default DEFAULT_ATTEMPTS;
 
     /**
      * The name of the persistence unit to retry deadlocks on. This defaults to the default persistence unit.

--- a/src/main/java/org/ccci/gto/persistence/DeadLockRetry.java
+++ b/src/main/java/org/ccci/gto/persistence/DeadLockRetry.java
@@ -12,4 +12,9 @@ public @interface DeadLockRetry {
      * Retry count. -1 indicates to use the default number of retries.
      */
     int attempts() default -1;
+
+    /**
+     * The name of the persistence unit to retry deadlocks on. This defaults to the default persistence unit.
+     */
+    String unitName() default "";
 }

--- a/src/main/java/org/ccci/gto/persistence/DeadLockRetryAspect.java
+++ b/src/main/java/org/ccci/gto/persistence/DeadLockRetryAspect.java
@@ -1,18 +1,13 @@
 package org.ccci.gto.persistence;
 
+import static org.ccci.gto.persistence.DeadLockRetry.DEFAULT_ATTEMPTS;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
-import org.springframework.dao.ConcurrencyFailureException;
 
 import javax.annotation.Nonnull;
-import javax.persistence.EntityManager;
-import javax.persistence.OptimisticLockException;
-import java.util.Optional;
 
 /**
  * This Aspect will cause methods to retry if there is a notion of a deadlock.
@@ -21,16 +16,7 @@ import java.util.Optional;
  * the transaction advice (we want a fresh transaction each time we retry).</emf>
  */
 @Aspect
-public abstract class DeadLockRetryAspect implements Ordered {
-    private static final Logger LOG = LoggerFactory.getLogger(DeadLockRetryAspect.class);
-
-    private int order = LOWEST_PRECEDENCE;
-
-    private int defaultAttempts = 3;
-
-    @Autowired
-    private EntityManagerResolver entityManagerResolver;
-
+public abstract class DeadLockRetryAspect extends DeadLockRetryAspectSupport implements Ordered {
     /**
      * Deadlock retry. The aspect applies to every service method with the annotation {@link DeadLockRetry}
      *
@@ -41,92 +27,21 @@ public abstract class DeadLockRetryAspect implements Ordered {
      */
     @Around(value = "@annotation(deadlockRetry)", argNames = "deadlockRetry")
     public Object deadlockRetry(final ProceedingJoinPoint pjp, final DeadLockRetry deadlockRetry) throws Throwable {
-        int attempts = deadlockRetry.attempts();
-        if (attempts == -1) {
-            attempts = defaultAttempts;
-        }
-        return internalDeadlockRetry(pjp, deadlockRetry.unitName(), attempts);
+        return wrapJoinPoint(pjp::proceed, deadlockRetry.unitName(), deadlockRetry.attempts());
     }
 
     /**
      * Deadlock retry. This method can be used for &gt;aop:advice /&lt; XML config.
      */
     public Object deadlockRetry(final ProceedingJoinPoint pjp) throws Throwable {
-        return internalDeadlockRetry(pjp, "", defaultAttempts);
+        return wrapJoinPoint(pjp::proceed, "", DEFAULT_ATTEMPTS);
     }
 
     public Object deadlockRetry(final ProceedingJoinPoint pjp, @Nonnull final String unitName) throws Throwable {
-        return internalDeadlockRetry(pjp, unitName, defaultAttempts);
+        return wrapJoinPoint(pjp::proceed, unitName, DEFAULT_ATTEMPTS);
     }
 
-    @Nonnull
-    private Optional<EntityManager> resolveEntityManager(@Nonnull final String unitName) {
-        return "".equals(unitName) ? entityManagerResolver.defaultEntityManager() :
-                entityManagerResolver.resolveEntityManager(unitName);
-    }
-
-    private Object internalDeadlockRetry(final ProceedingJoinPoint pjp, @Nonnull final String unitName, int attempts)
-            throws Throwable {
-        LOG.trace("entering DeadLockRetry");
-
-        // loop until we complete successfully or have too many deadlock exceptions
-        final EntityManager em = resolveEntityManager(unitName).orElse(null);
-        final boolean inTransaction = em != null && em.isJoinedToTransaction();
-        while (true) {
-            try {
-                // attempt to proceed
-                return pjp.proceed();
-            } catch (final Throwable e) {
-                // handle deadlock exceptions when we still have attempts remaining
-                if (em != null && !inTransaction && attempts > 0 && isDeadlock(em, e)) {
-                    LOG.error("Deadlocked, attempts remaining: {}", attempts, e);
-                    attempts--;
-                    continue;
-                }
-
-                // propagate the caught exception
-                throw e;
-            }
-        }
-    }
-
-    private boolean isDeadlock(@Nonnull final EntityManager em, @Nonnull final Throwable e) {
-        return e instanceof OptimisticLockException || e instanceof ConcurrencyFailureException ||
-                isImplDeadlock(em, e);
-    }
-
-    /**
-     * check if the exception is a deadlock error.
-     *
-     * @param exception the persistence error
-     * @return is a deadlock error
-     */
-    protected abstract boolean isImplDeadlock(@Nonnull EntityManager em, @Nonnull Throwable exception);
-
-    public int getDefaultAttempts() {
-        return defaultAttempts;
-    }
-
-    public void setDefaultAttempts(final int attempts) {
-        this.defaultAttempts = attempts;
-    }
-
-    public void setEntityManagerResolver(@Nonnull final EntityManagerResolver resolver) {
-        entityManagerResolver = resolver;
-    }
-
-    @Override
-    public int getOrder() {
-        return this.order;
-    }
-
-    /**
-     * Sets the order.
-     * 
-     * @param order
-     *            the order to set
-     */
-    public void setOrder(final int order) {
-        this.order = order;
+    public Object deadlockRetry(final ProceedingJoinPoint pjp, @Nonnull final String unitName, final int attempts) throws Throwable {
+        return wrapJoinPoint(pjp::proceed, unitName, attempts);
     }
 }

--- a/src/main/java/org/ccci/gto/persistence/DeadLockRetryAspectSupport.java
+++ b/src/main/java/org/ccci/gto/persistence/DeadLockRetryAspectSupport.java
@@ -1,0 +1,99 @@
+package org.ccci.gto.persistence;
+
+import static org.ccci.gto.persistence.DeadLockRetry.DEFAULT_ATTEMPTS;
+
+import org.ccci.gto.persistence.tx.Closure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.dao.ConcurrencyFailureException;
+
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+import javax.persistence.OptimisticLockException;
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+
+abstract class DeadLockRetryAspectSupport implements Ordered {
+    private static final Logger LOG = LoggerFactory.getLogger(DeadLockRetryAspectSupport.class);
+
+    @NotNull
+    @Autowired
+    private EntityManagerResolver entityManagerResolver;
+
+    private int defaultAttempts = 3;
+
+    private int order = LOWEST_PRECEDENCE;
+
+    public void setEntityManagerResolver(@Nonnull final EntityManagerResolver resolver) {
+        entityManagerResolver = resolver;
+    }
+
+    public void setDefaultAttempts(final int attempts) {
+        defaultAttempts = attempts;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * Sets the order.
+     *
+     * @param order
+     *            the order to set
+     */
+    public void setOrder(final int order) {
+        this.order = order;
+    }
+
+    @Nonnull
+    protected final Optional<EntityManager> resolveEntityManager(@Nonnull final String unitName) {
+        return "".equals(unitName) ? entityManagerResolver.defaultEntityManager() :
+                entityManagerResolver.resolveEntityManager(unitName);
+    }
+
+    protected final <X extends Throwable> Object wrapJoinPoint(@Nonnull final Closure<Object, X> joinPoint,
+                                                               @Nonnull final String unitName, int attempts) throws X {
+        if (attempts == DEFAULT_ATTEMPTS) {
+            attempts = defaultAttempts;
+        }
+
+        LOG.trace("entering DeadLockRetry");
+
+        // loop until we complete successfully or have too many deadlock exceptions
+        final EntityManager em = resolveEntityManager(unitName).orElse(null);
+        final boolean inTransaction = em != null && em.isJoinedToTransaction();
+        while (true) {
+            try {
+                // attempt to proceed
+                return joinPoint.run();
+            } catch (final Throwable e) {
+                // handle deadlock exceptions when we still have attempts remaining
+                if (em != null && !inTransaction && attempts > 0 && isDeadlock(em, e)) {
+                    LOG.error("Deadlocked, attempts remaining: {}", attempts, e);
+                    attempts--;
+                    continue;
+                }
+
+                // propagate the caught exception
+                throw e;
+            }
+        }
+    }
+
+    private boolean isDeadlock(@Nonnull final EntityManager em, @Nonnull final Throwable e) {
+        return e instanceof OptimisticLockException || e instanceof ConcurrencyFailureException ||
+                isImplDeadlock(em, e);
+    }
+
+    /**
+     * check if the exception is a deadlock error.
+     *
+     * @param exception the persistence error
+     * @return is a deadlock error
+     */
+    protected abstract boolean isImplDeadlock(@Nonnull EntityManager em, @Nonnull Throwable exception);
+}

--- a/src/main/java/org/ccci/gto/persistence/DefaultEntityManagerResolver.java
+++ b/src/main/java/org/ccci/gto/persistence/DefaultEntityManagerResolver.java
@@ -1,0 +1,21 @@
+package org.ccci.gto.persistence;
+
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Optional;
+
+public class DefaultEntityManagerResolver implements EntityManagerResolver {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public void setEntityManager(final EntityManager manager) {
+        entityManager = manager;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<EntityManager> defaultEntityManager() {
+        return Optional.ofNullable(entityManager);
+    }
+}

--- a/src/main/java/org/ccci/gto/persistence/EntityManagerResolver.java
+++ b/src/main/java/org/ccci/gto/persistence/EntityManagerResolver.java
@@ -1,0 +1,17 @@
+package org.ccci.gto.persistence;
+
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+public interface EntityManagerResolver {
+    @Nonnull
+    default Optional<EntityManager> resolveEntityManager(@Nonnull String unitName) {
+        return Optional.empty();
+    }
+
+    @Nonnull
+    default Optional<EntityManager> defaultEntityManager() {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/ccci/gto/persistence/aopalliance/DeadLockRetryAdvisor.java
+++ b/src/main/java/org/ccci/gto/persistence/aopalliance/DeadLockRetryAdvisor.java
@@ -1,0 +1,41 @@
+package org.ccci.gto.persistence.aopalliance;
+
+import static org.ccci.gto.persistence.DeadLockRetry.DEFAULT_ATTEMPTS;
+
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.ccci.gto.persistence.DeadLockRetry;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.PointcutAdvisor;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+public final class DeadLockRetryAdvisor extends DeadLockRetryMethodInterceptorFactory implements PointcutAdvisor {
+    private final AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+    private final MethodInterceptor defaultAdvice = invocation -> {
+        final DeadLockRetry deadLockRetry = invocation.getMethod().getAnnotation(DeadLockRetry.class);
+        if (deadLockRetry != null) {
+            return wrapJoinPoint(invocation::proceed, deadLockRetry.unitName(), deadLockRetry.attempts());
+        }
+
+        return wrapJoinPoint(invocation::proceed, "", DEFAULT_ATTEMPTS);
+    };
+
+    public DeadLockRetryAdvisor() {
+        pointcut.setExpression("@annotation(org.ccci.gto.persistence.DeadLockRetry)");
+    }
+
+    @Override
+    public Pointcut getPointcut() {
+        return pointcut;
+    }
+
+    @Override
+    public Advice getAdvice() {
+        return defaultAdvice;
+    }
+
+    @Override
+    public boolean isPerInstance() {
+        return false;
+    }
+}

--- a/src/main/java/org/ccci/gto/persistence/aopalliance/DeadLockRetryMethodInterceptorFactory.java
+++ b/src/main/java/org/ccci/gto/persistence/aopalliance/DeadLockRetryMethodInterceptorFactory.java
@@ -1,0 +1,22 @@
+package org.ccci.gto.persistence.aopalliance;
+
+import static org.ccci.gto.persistence.DeadLockRetry.DEFAULT_ATTEMPTS;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.ccci.gto.persistence.DeadLockRetryAspectSupport;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DeadLockRetryMethodInterceptorFactory extends DeadLockRetryAspectSupport {
+    private final Map<String, MethodInterceptor> advice = new HashMap<>();
+
+    public MethodInterceptor getAdvice(@Nonnull final String unitName) {
+        return advice.computeIfAbsent(unitName, this::createAdvice);
+    }
+
+    private MethodInterceptor createAdvice(@Nonnull final String unitName) {
+        return invocation -> wrapJoinPoint(invocation::proceed, unitName, DEFAULT_ATTEMPTS);
+    }
+}

--- a/src/main/java/org/ccci/gto/persistence/aspectj/AspectJDeadLockRetryAspect.java
+++ b/src/main/java/org/ccci/gto/persistence/aspectj/AspectJDeadLockRetryAspect.java
@@ -36,14 +36,15 @@ public class AspectJDeadLockRetryAspect extends DeadLockRetryAspectSupport imple
      * Deadlock retry. This method can be used for &gt;aop:advice /&lt; XML config.
      */
     public Object deadlockRetry(final ProceedingJoinPoint pjp) throws Throwable {
-        return wrapJoinPoint(pjp::proceed, "", DEFAULT_ATTEMPTS);
+        return deadlockRetry(pjp, "", DEFAULT_ATTEMPTS);
     }
 
     public Object deadlockRetry(final ProceedingJoinPoint pjp, @Nonnull final String unitName) throws Throwable {
-        return wrapJoinPoint(pjp::proceed, unitName, DEFAULT_ATTEMPTS);
+        return deadlockRetry(pjp, unitName, DEFAULT_ATTEMPTS);
     }
 
-    public Object deadlockRetry(final ProceedingJoinPoint pjp, @Nonnull final String unitName, final int attempts) throws Throwable {
+    public Object deadlockRetry(final ProceedingJoinPoint pjp, @Nonnull final String unitName, final int attempts)
+            throws Throwable {
         return wrapJoinPoint(pjp::proceed, unitName, attempts);
     }
 }

--- a/src/main/java/org/ccci/gto/persistence/aspectj/AspectJDeadLockRetryAspect.java
+++ b/src/main/java/org/ccci/gto/persistence/aspectj/AspectJDeadLockRetryAspect.java
@@ -1,10 +1,12 @@
-package org.ccci.gto.persistence;
+package org.ccci.gto.persistence.aspectj;
 
 import static org.ccci.gto.persistence.DeadLockRetry.DEFAULT_ATTEMPTS;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.ccci.gto.persistence.DeadLockRetry;
+import org.ccci.gto.persistence.DeadLockRetryAspectSupport;
 import org.springframework.core.Ordered;
 
 import javax.annotation.Nonnull;
@@ -16,7 +18,7 @@ import javax.annotation.Nonnull;
  * the transaction advice (we want a fresh transaction each time we retry).</emf>
  */
 @Aspect
-public abstract class DeadLockRetryAspect extends DeadLockRetryAspectSupport implements Ordered {
+public class AspectJDeadLockRetryAspect extends DeadLockRetryAspectSupport implements Ordered {
     /**
      * Deadlock retry. The aspect applies to every service method with the annotation {@link DeadLockRetry}
      *

--- a/src/main/java/org/ccci/gto/persistence/hibernate/HibernateDeadLockDetector.java
+++ b/src/main/java/org/ccci/gto/persistence/hibernate/HibernateDeadLockDetector.java
@@ -1,7 +1,6 @@
 package org.ccci.gto.persistence.hibernate;
 
-import org.aspectj.lang.annotation.Aspect;
-import org.ccci.gto.persistence.DeadLockRetryAspect;
+import org.ccci.gto.persistence.DeadLockDetector;
 import org.hibernate.JDBCException;
 import org.hibernate.SessionFactory;
 import org.hibernate.dialect.Dialect;
@@ -15,16 +14,16 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceException;
 
-@Aspect
-public class HibernateDeadLockRetryAspect extends DeadLockRetryAspect {
+public class HibernateDeadLockDetector implements DeadLockDetector {
     /**
      * check if the exception is a deadlock error.
-     * 
+     *
      * @param exception
      *            the persitence error
      * @return is a deadlock error
      */
-    protected boolean isImplDeadlock(@Nonnull final EntityManager em, @Nonnull final Throwable exception) {
+    @Override
+    public boolean isDeadlock(@Nonnull final EntityManager em, @Nonnull final Throwable exception) {
         if (exception instanceof PersistenceException) {
             final Dialect dialect = getDialect(em);
             if (dialect instanceof ErrorCodeAware) {
@@ -40,7 +39,7 @@ public class HibernateDeadLockRetryAspect extends DeadLockRetryAspect {
 
     /**
      * Returns the currently used dialect
-     * 
+     *
      * @return the dialect
      */
     @Nullable

--- a/src/main/java/org/ccci/gto/persistence/hibernate/HibernateDeadLockRetryAspect.java
+++ b/src/main/java/org/ccci/gto/persistence/hibernate/HibernateDeadLockRetryAspect.java
@@ -11,6 +11,7 @@ import org.hibernate.jpa.HibernateEntityManagerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceException;
 
@@ -23,9 +24,9 @@ public class HibernateDeadLockRetryAspect extends DeadLockRetryAspect {
      *            the persitence error
      * @return is a deadlock error
      */
-    protected boolean isImplDeadlock(@Nonnull final Throwable exception) {
+    protected boolean isImplDeadlock(@Nonnull final EntityManager em, @Nonnull final Throwable exception) {
         if (exception instanceof PersistenceException) {
-            final Dialect dialect = getDialect();
+            final Dialect dialect = getDialect(em);
             if (dialect instanceof ErrorCodeAware) {
                 final Throwable cause = exception.getCause();
                 if (cause instanceof JDBCException) {
@@ -43,7 +44,7 @@ public class HibernateDeadLockRetryAspect extends DeadLockRetryAspect {
      * @return the dialect
      */
     @Nullable
-    private Dialect getDialect() {
+    private Dialect getDialect(@Nonnull final EntityManager em) {
         final EntityManagerFactory emf = em.getEntityManagerFactory();
         if (emf instanceof HibernateEntityManagerFactory) {
             final SessionFactory sessionFactory = ((HibernateEntityManagerFactory) emf).getSessionFactory();

--- a/src/test/resources/org/ccci/gto/persistence/hibernate/deadlocks.xml
+++ b/src/test/resources/org/ccci/gto/persistence/hibernate/deadlocks.xml
@@ -47,5 +47,7 @@
       p:defaultAttempts="15"
       p:order="100" />
 
+  <bean class="org.ccci.gto.persistence.DefaultEntityManagerResolver" />
+
   <bean class="org.ccci.gto.persistence.tx.DefaultRetryingTransactionService" />
 </beans>

--- a/src/test/resources/org/ccci/gto/persistence/hibernate/deadlocks.xml
+++ b/src/test/resources/org/ccci/gto/persistence/hibernate/deadlocks.xml
@@ -43,11 +43,13 @@
   <tx:annotation-driven transaction-manager="transactionManager" order="200" />
 
   <aop:aspectj-autoproxy />
-  <bean id="deadlockRetryAspectBean" class="org.ccci.gto.persistence.hibernate.HibernateDeadLockRetryAspect"
+  <bean id="deadlockRetryAspectBean" class="org.ccci.gto.persistence.aspectj.AspectJDeadLockRetryAspect"
       p:defaultAttempts="15"
       p:order="100" />
 
   <bean class="org.ccci.gto.persistence.DefaultEntityManagerResolver" />
 
   <bean class="org.ccci.gto.persistence.tx.DefaultRetryingTransactionService" />
+
+  <bean class="org.ccci.gto.persistence.hibernate.HibernateDeadLockDetector" />
 </beans>


### PR DESCRIPTION
This PR updates the JPA deadlock retry logic to be able to support multiple EntityManagers for different persistence units. This PR also adds support for being configured via AspectJ or via aopalliance MethodInterceptors.

This updated logic will be used by an upcoming PR within The Key.