### PR TITLE
Fix an Exception when using Hibernate 5.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <aspectj.version>1.8.6</aspectj.version>
-    <hibernate.version>4.3.9.Final</hibernate.version>
+    <hibernate.version>5.2.16.Final</hibernate.version>
     <hsqldb.version>2.3.3</hsqldb.version>
     <javax.validation.version>1.0.0.GA</javax.validation.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
     <mysql.version>5.1.36</mysql.version>
     <slf4j.version>1.6.6</slf4j.version>
-    <spring.version>4.2.0.RELEASE</spring.version>
+    <spring.version>4.3.0.RELEASE</spring.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
```
Apr 02 16:58:42 cas1 server[4018]: java.lang.NoSuchMethodError: org.hibernate.jpa.HibernateEntityManagerFactory.getSessionFactory()Lorg/hibernate/SessionFactory;
Apr 02 16:58:42 cas1 server[4018]: at org.ccci.gto.persistence.hibernate.HibernateDeadLockDetector.getDialect(HibernateDeadLockDetector.java:49) ~[extension-persistence-0.5.1.jar:?]
Apr 02 16:58:42 cas1 server[4018]: at org.ccci.gto.persistence.hibernate.HibernateDeadLockDetector.isDeadlock(HibernateDeadLockDetector.java:28) ~[extension-persistence-0.5.1.jar:?]
Apr 02 16:58:42 cas1 server[4018]: at org.ccci.gto.persistence.DeadLockRetryAspectSupport.lambda$isDeadlock$0(DeadLockRetryAspectSupport.java:105) ~[extension-persistence-0.5.1.jar:?]
Apr 02 16:58:42 cas1 server[4018]: at org.ccci.gto.persistence.DeadLockRetryAspectSupport$$Lambda$484/1806935506.test(Unknown Source) ~[?:?]
...
```